### PR TITLE
Fix: plainjs utils flattenReducer check for array before spread push (fixes #3)

### DIFF
--- a/packages/plainjs/src/utils.js
+++ b/packages/plainjs/src/utils.js
@@ -4,6 +4,10 @@ export function getProp(obj, path, defaultValue) {
 }
 
 export function flattenReducer(acc, arr) {
+  if (!Array.isArray(arr)) {
+    acc.push(arr);
+    return acc;
+  }
   try {
     // This is faster but susceptible to `RangeError: Maximum call stack size exceeded`
     acc.push(...arr);


### PR DESCRIPTION
Speeds up function substantially when receiving an object as it no longer relies on the error pathway from spread pushing a non-iterable object.