### PR TITLE
fix: add AsyncParser to whatwg export

### DIFF
--- a/dist/cdn/whatwg/index.js
+++ b/dist/cdn/whatwg/index.js
@@ -1,5 +1,7 @@
 // packages/whatwg/src/index.js
-import { default as default2 } from "./TransformStream.js";
+import { default as default2 } from "./AsyncParser.js";
+import { default as default3 } from "./TransformStream.js";
 export {
-  default2 as TransformStream
+  default2 as AsyncParser,
+  default3 as TransformStream
 };

--- a/packages/whatwg/src/index.js
+++ b/packages/whatwg/src/index.js
@@ -1,1 +1,2 @@
+export { default as AsyncParser } from './AsyncParser.js';
 export { default as TransformStream } from './TransformStream.js';


### PR DESCRIPTION
AsyncParser is not currently available from the whatwg package even though the docs suggest it should be https://juanjodiaz.github.io/json2csv/#/parsers/whatwg-async-parser

This PR adds it as an export from the whatwg index.js file.