### PR TITLE
fix: only include built files in packages

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,6 +27,9 @@
   "bin": {
     "json2csv": "./bin/json2csv.js"
   },
+  "files": [
+    "bin"
+  ],
   "scripts": {
     "lint": "eslint src test",
     "build:mjs": "tsc --module esnext --outDir ./bin",

--- a/packages/formatters/package.json
+++ b/packages/formatters/package.json
@@ -35,6 +35,9 @@
     }
   },
   "main": "dist/mjs/index.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "lint": "eslint src",
     "build:cjs": "tsc --module commonjs --verbatimModuleSyntax false --outDir ./dist/cjs && node ../../build-cjs.js",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -35,6 +35,9 @@
     }
   },
   "main": "dist/mjs/index.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "lint": "eslint src test",
     "build:cjs": "tsc --module commonjs --verbatimModuleSyntax false --outDir ./dist/cjs && node ../../build-cjs.js",

--- a/packages/plainjs/package.json
+++ b/packages/plainjs/package.json
@@ -35,6 +35,9 @@
     }
   },
   "main": "dist/mjs/index.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "lint": "eslint src test",
     "build:cjs": "tsc --module commonjs --verbatimModuleSyntax false --outDir ./dist/cjs && node ../../build-cjs.js",

--- a/packages/transforms/package.json
+++ b/packages/transforms/package.json
@@ -35,6 +35,9 @@
     }
   },
   "main": "dist/mjs/index.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "lint": "eslint src",
     "build:cjs": "tsc --module commonjs --verbatimModuleSyntax false --outDir ./dist/cjs && node ../../build-cjs.js",

--- a/packages/whatwg/package.json
+++ b/packages/whatwg/package.json
@@ -35,6 +35,9 @@
     }
   },
   "main": "dist/mjs/index.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "lint": "eslint src test",
     "build:cjs": "tsc --module commonjs --verbatimModuleSyntax false --outDir ./dist/cjs && node ../../build-cjs.js",


### PR DESCRIPTION
This PR adds the files option to the package.json file so that only built files are included in the packages.

Closes #41 