### PR TITLE
docs: fix `flatten()` args in Transform page examples

### DIFF
--- a/docs/advanced-options/transforms.md
+++ b/docs/advanced-options/transforms.md
@@ -285,7 +285,7 @@ try {
   const opts = {
     transforms: [
       unwind({ paths: ['fieldToUnwind','fieldToUnwind.subfieldToUnwind'], blankOut: true }),
-      flatten({ object: true, array: true, separator: '_'}),
+      flatten({ objects: true, arrays: true, separator: '_'}),
       addCounter()
     ]
   };
@@ -307,7 +307,7 @@ import { addCounter } from './custom-transforms';
 const opts = {
   transforms: [
     unwind({ paths: ['fieldToUnwind','fieldToUnwind.subfieldToUnwind'], blankOut: true }),
-    flatten({ object: true, array: true, separator: '_'}),
+    flatten({ objects: true, arrays: true, separator: '_'}),
     addCounter()
   ]
 };
@@ -336,7 +336,7 @@ const output = createWriteStream(outputPath, { encoding: 'utf8' });
 const opts = {
   transforms: [
     unwind({ paths: ['fieldToUnwind','fieldToUnwind.subfieldToUnwind'], blankOut: true }),
-    flatten({ object: true, array: true, separator: '_'}),
+    flatten({ objects: true, arrays: true, separator: '_'}),
     addCounter()
   ]
 };
@@ -360,7 +360,7 @@ import { addCounter } from './custom-transforms';
 const opts = {
   transforms: [
     unwind({ paths: ['fieldToUnwind','fieldToUnwind.subfieldToUnwind'], blankOut: true }),
-    flatten({ object: true, array: true, separator: '_'}),
+    flatten({ objects: true, arrays: true, separator: '_'}),
     addCounter()
   ]
 };
@@ -379,7 +379,7 @@ import { addCounter } from './custom-transforms';
 const opts = {
   transforms: [
     unwind({ paths: ['fieldToUnwind','fieldToUnwind.subfieldToUnwind'], blankOut: true }),
-    flatten({ object: true, array: true, separator: '_'}),
+    flatten({ objects: true, arrays: true, separator: '_'}),
     addCounter()
   ]
 };


### PR DESCRIPTION
The args to `flatten()` in the examples are singular, but they should be plural as per the type definition.