### PR TITLE
chore(docs): improve migration guide to reflect correct constructor

### DIFF
--- a/docs/migration-guides/5-to-6.md
+++ b/docs/migration-guides/5-to-6.md
@@ -33,9 +33,11 @@ const { number: numberFormatter, string: stringFormatter, stringExcel: stringExc
 These 2 methods are equivalent to:
 
 ```js
+const { Parser } = require('@json2csv/plainjs');
 const parse = (data, opts) => new Parser(opts).parse(data);
 
-const parseAsync = (data, opts, transformOpts) => new NodeAsyncParser(opts, transformOpts).parse(data).promise();
+const { AsyncParser } = require('@json2csv/node');
+const parseAsync = (data, opts, transformOpts) => new AsyncParser(opts, transformOpts).parse(data).promise();
 ```
 
 ## AsyncParser changes


### PR DESCRIPTION
# chore(docs): improve migration guide to reflect correct constructor

## Introduction

During a migration process, I realized that the documentation did not reflect the correct name of the constructor used in the asynchronous analyzer.

In reality, this PR is optional, but I guess it will be nice to correctly reflect the changes required to migrate the library from lower versions in a correct way.

## Change

1. Replace `NodeAsyncParser` with `AsyncParser`
2. Reflect on which packages these constructors come from